### PR TITLE
add movie seeds verification step

### DIFF
--- a/rottenpotatoes/features/filter_movie_list.feature
+++ b/rottenpotatoes/features/filter_movie_list.feature
@@ -20,6 +20,7 @@ Background: movies have been added to database
   | Chicken Run             | G      | 21-Jun-2000  |
 
   And  I am on the RottenPotatoes home page
+  Then 10 seed movies should exist
 
 Scenario: restrict to movies with 'PG' or 'R' ratings
   # enter step(s) to check the 'PG' and 'R' checkboxes

--- a/rottenpotatoes/features/sort_movie_list.feature
+++ b/rottenpotatoes/features/sort_movie_list.feature
@@ -1,11 +1,11 @@
 Feature: display list of movies sorted by different criteria
- 
+
   As an avid moviegoer
   So that I can quickly browse movies based on my preferences
   I want to see movies sorted by title or release date
 
 Background: movies have been added to database
-  
+
   Given the following movies exist:
   | title                   | rating | release_date |
   | Aladdin                 | G      | 25-Nov-1992  |
@@ -20,6 +20,7 @@ Background: movies have been added to database
   | Chicken Run             | G      | 21-Jun-2000  |
 
   And I am on the RottenPotatoes home page
+  Then 10 seed movies should exist
 
 Scenario: sort movies alphabetically
   When I follow "Movie Title"

--- a/rottenpotatoes/features/step_definitions/movie_steps.rb
+++ b/rottenpotatoes/features/step_definitions/movie_steps.rb
@@ -8,6 +8,10 @@ Given /the following movies exist/ do |movies_table|
   fail "Unimplemented"
 end
 
+Then /(.*) seed movies should exist/ do | n_seeds |
+  Movie.count.should be n_seeds.to_i
+end
+
 # Make sure that one string (regexp) occurs before or after another one
 #   on the same page
 


### PR DESCRIPTION
a student noticed that if you do nothing but comment out the `fail "Unimplemented"` in the movie seed step in movie_steps.rb:8 then cucumber will report all tests passing which is confusing

i remember when i first did this assignment i figured the proper thing to do was to put this validation as the return value of the `Given the following movies exist:` step but the homework does not specify this - therefore the student may never see a meaningful failure during part 1 of the assignment

this patch verifies that the movies actually exist as a final background step so that some test will actually fail if part 1 of the assignment is not correct
